### PR TITLE
change SteamApps to steamapps for windows

### DIFF
--- a/src/libraryfolders.rs
+++ b/src/libraryfolders.rs
@@ -30,7 +30,12 @@ pub struct LibraryFolders {
 
 impl LibraryFolders {
 	pub(crate) fn discover(&mut self, path: &PathBuf) {
-		let steamapps = path.join("SteamApps");
+		#[cfg(target_os="windows")]
+		let steamapps_name = "steamapps";
+		#[cfg(not(target_os="windows"))]
+		let steamapps_name = "SteamApps";
+		
+		let steamapps = path.join(steamapps_name);
 		self.paths.push(steamapps.clone());
 
 		let libraryfolders_vdf_path = steamapps.join("libraryfolders.vdf");
@@ -56,7 +61,7 @@ impl LibraryFolders {
 							key.parse::<u32>().ok()?;
 							Some(PathBuf::from(
 								libraryfolders_vdf.get(key)?.as_str()?.to_string()
-							).join("SteamApps"))
+							).join(steamapps_name))
 						}).collect::<Vec<PathBuf>>()
 					)
 				}


### PR DESCRIPTION
Trying to improve windows compatibility, I assume you don't use windows (which honestly I understand) so the crate doesn't currently work on windows unfortunately, there is also another issue that I will raise soon, but unfortunately that one is more complicated and annoying and I don't have a simple solution to it.

PS: thanks for making this crate, it's exactly what I was looking for in terms of ease of use and I hope you continue to maintain it.