### PR TITLE
Fix `libraryfolders.vdf` parsing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,5 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ steamy-vdf = "0.*.*"
 anyhow = "1.*"
 regex = "1.*"
 lazy_static = "1.*"
+keyvalues-parser = "0.1"
 steamid-ng = { version = "1.*", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl SteamDir {
 		    Ok(installation_regkey) => installation_regkey,
 		    Err(_) => return None
 		};
-		
+
 		// The InstallPath key will contain the full path to the Steam directory
 		let install_path_str: String = match installation_regkey.get_value("InstallPath") {
 			Ok(install_path_str) => install_path_str,
@@ -292,7 +292,7 @@ impl SteamDir {
 		    Some(home_dir) => home_dir,
 		    None => return None
 		};
-		
+
 		// Find Library/Application Support/Steam
 		let install_path = home_dir.join("Library/Application Support/Steam");
 		return match install_path.is_dir() {
@@ -314,7 +314,7 @@ impl SteamDir {
 		    Some(home_dir) => home_dir,
 		    None => return None
 		};
-		
+
 		// Find .steam/steam
 		let install_path = home_dir.join(".steam/steam");
 		return match install_path.is_dir() {

--- a/src/libraryfolders.rs
+++ b/src/libraryfolders.rs
@@ -82,7 +82,7 @@ impl LibraryFolders {
 
 			self.paths = library_folders;
 		}
-		
+
 		self.discovered = true;
 
 		Some(())

--- a/src/steamapp.rs
+++ b/src/steamapp.rs
@@ -32,7 +32,7 @@ pub struct SteamApp {
 
 	/// The store name of the Steam app.
 	pub name: Option<String>,
-	
+
 	#[cfg(not(feature="steamid_ng"))]
 	/// The SteamID64 of the last Steam user that played this game on the filesystem.
 	///

--- a/src/steamapps.rs
+++ b/src/steamapps.rs
@@ -16,7 +16,7 @@ pub(crate) struct SteamApps {
 impl SteamApps {
 	pub(crate) fn discover_apps(&mut self, libraryfolders: &LibraryFolders) {
 		self.apps.drain();
-		
+
 		for libraryfolder in &libraryfolders.paths {
 			let read_dir = libraryfolder.read_dir();
 			if read_dir.is_err() { continue }
@@ -52,7 +52,7 @@ impl SteamApps {
 				};
 
 				path.pop(); path.push("common");
-				
+
 				self.apps.insert(
 					app_id,
 					SteamApp::new(&path, &vdf)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,7 +20,7 @@ fn find_library_folders() {
 	assert!(steamdir_found.is_some());
 
 	let mut steamdir = steamdir_found.unwrap();
-	
+
 	steamdir.libraryfolders.discover(&steamdir.path);
 	assert!(steamdir.libraryfolders().paths.len() > 1);
 
@@ -33,7 +33,7 @@ fn find_app() {
 	assert!(steamdir_found.is_some());
 
 	let mut steamdir = steamdir_found.unwrap();
-	
+
 	let steamapp = steamdir.app(&APP_ID);
 	assert!(steamapp.is_some());
 
@@ -46,10 +46,10 @@ fn app_details() {
 	assert!(steamdir_found.is_some());
 
 	let mut steamdir = steamdir_found.unwrap();
-	
+
 	let steamapp = steamdir.app(&APP_ID);
 	assert!(steamapp.is_some());
-	
+
 	assert!(steamapp.unwrap().name.is_some());
 	assert!(steamapp.unwrap().last_user.is_some());
 }
@@ -60,7 +60,7 @@ fn all_apps() {
 	assert!(steamdir_found.is_some());
 
 	let mut steamdir = steamdir_found.unwrap();
-	
+
 	let steamapps = steamdir.apps();
 	assert!(!steamapps.is_empty());
 	assert!(steamapps.keys().len() > 1);
@@ -74,14 +74,14 @@ fn all_apps_get_one() {
 	assert!(steamdir_found.is_some());
 
 	let mut steamdir = steamdir_found.unwrap();
-	
+
 	let steamapps = steamdir.apps();
 	assert!(!steamapps.is_empty());
 	assert!(steamapps.keys().len() > 1);
-	
+
 	let steamapp = steamdir.app(&APP_ID);
 	assert!(steamapp.is_some());
-	
+
 	assert!(steamapp.unwrap().name.is_some());
 	assert!(steamapp.unwrap().last_user.is_some());
 }


### PR DESCRIPTION
This switches just the `libraryfolders.vdf` parsing to use [`keyvalues-parser`](https://docs.rs/keyvalues-parser/latest/keyvalues_parser/) which gets things into a working state for now (all the tests are passing for me :partying_face:). I was not able to test on windows though since anti-virus seemed to be silently killing the test program I cross-compiled

I do have plans to swap out the app manifest parsing as well since it seems a bit silly to use two separate parsers, and there's no telling what other issues the old parser may have on random app manifest files

_Side note: The `.editorconfig` change was because the editor config used `crlf` while all the other files used just `lf` so `.editorconfig` seemed like the smaller change and `lf` is more common AFAIK_