### PR TITLE
Deps cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ steamid_ng = ["steamid-ng"]
 
 [dependencies]
 steamy-vdf = "0.*.*"
-anyhow = "1.*"
 regex = "1.*"
 lazy_static = "1.*"
 steamid-ng = { version = "1.*", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ steamid_ng = ["steamid-ng"]
 
 [dependencies]
 steamy-vdf = "0.*.*"
-regex = "1.*"
-lazy_static = "1.*"
 steamid-ng = { version = "1.*", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,6 @@
 #[cfg(not(any(target_os="windows", target_os="macos", target_os="linux")))]
 compile_error!("Unsupported operating system!");
 
-#[macro_use] extern crate lazy_static;
-
 use std::{collections::HashMap, path::PathBuf};
 
 #[cfg(target_os="windows")]


### PR DESCRIPTION
Coming in just a hair too late for the version bump from the looks of it

This change just removed some deps. `anyhow` wasn't used, and `regex` with `lazy_static` was just for extracting out the app id from the manifest file name which is easy enough to do with some manual string manipulation