### PR TITLE
Format with `cargo fmt`

### DIFF
--- a/src/libraryfolders.rs
+++ b/src/libraryfolders.rs
@@ -1,4 +1,7 @@
-use std::{path::{Path, PathBuf}, fs};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use keyvalues_parser::Vdf;
 
@@ -23,68 +26,70 @@ use keyvalues_parser::Vdf;
 /// ```
 #[derive(Default, Clone, Debug)]
 pub struct LibraryFolders {
-	/// A `Vec<PathBuf>` of Steam library folder paths.
-	///
-	/// This will always include the Steam installation directory's `SteamApps` folder.
-	pub paths: Vec<PathBuf>,
-	pub(crate) discovered: bool
+    /// A `Vec<PathBuf>` of Steam library folder paths.
+    ///
+    /// This will always include the Steam installation directory's `SteamApps` folder.
+    pub paths: Vec<PathBuf>,
+    pub(crate) discovered: bool,
 }
 
 impl LibraryFolders {
-	/// Discovers all the steam libraries from `libraryfolders.vdf`
-	///
-	/// We want all the library paths from `libraryfolders.vdf` which has the following structure
-	///
-	/// ```vdf
-	/// "libraryfolders"
-	/// {
-	///     ...
-	///     "0"
-	///     {
-	///         "path"    "/path/to/first/library"
-	///         ...
-	///     }
-	///     "1"
-	///     {
-	///         "path"    "/path/to/second/library"
-	///         ...
-	///     }
-	///     ...
-	/// }
-	/// ```
-	pub(crate) fn discover(&mut self, path: &Path) {
-		let _ = self._discover(path);
-	}
+    /// Discovers all the steam libraries from `libraryfolders.vdf`
+    ///
+    /// We want all the library paths from `libraryfolders.vdf` which has the following structure
+    ///
+    /// ```vdf
+    /// "libraryfolders"
+    /// {
+    ///     ...
+    ///     "0"
+    ///     {
+    ///         "path"    "/path/to/first/library"
+    ///         ...
+    ///     }
+    ///     "1"
+    ///     {
+    ///         "path"    "/path/to/second/library"
+    ///         ...
+    ///     }
+    ///     ...
+    /// }
+    /// ```
+    pub(crate) fn discover(&mut self, path: &Path) {
+        let _ = self._discover(path);
+    }
 
-	fn _discover(&mut self, path: &Path) -> Option<()> {
-		let steamapps = path.join("steamapps");
-		self.paths.push(steamapps.clone());
+    fn _discover(&mut self, path: &Path) -> Option<()> {
+        let steamapps = path.join("steamapps");
+        self.paths.push(steamapps.clone());
 
-		let libraryfolders_vdf_path = steamapps.join("libraryfolders.vdf");
-		if libraryfolders_vdf_path.is_file() {
-			let vdf_text = fs::read_to_string(&libraryfolders_vdf_path).ok()?;
-			let value = Vdf::parse(&vdf_text).ok()?.value;
-			let obj = value.get_obj()?;
+        let libraryfolders_vdf_path = steamapps.join("libraryfolders.vdf");
+        if libraryfolders_vdf_path.is_file() {
+            let vdf_text = fs::read_to_string(&libraryfolders_vdf_path).ok()?;
+            let value = Vdf::parse(&vdf_text).ok()?.value;
+            let obj = value.get_obj()?;
 
-			let library_folders: Vec<_> = obj.iter().filter(|(key, values)| {
-				key.parse::<u32>().is_ok() && values.len() == 1
-			}).filter_map(|(_, values)| {
-				let library_folder_string = values
-					.get(0)?
-					.get_obj()?
-					.get("path")?
-					.get(0)?
-					.get_str()?
-					.to_string();
-				let library_folder = PathBuf::from(library_folder_string).join("steamapps");
-				Some(library_folder)
-			}).collect();
+            let library_folders: Vec<_> = obj
+                .iter()
+                .filter(|(key, values)| key.parse::<u32>().is_ok() && values.len() == 1)
+                .filter_map(|(_, values)| {
+                    let library_folder_string = values
+                        .get(0)?
+                        .get_obj()?
+                        .get("path")?
+                        .get(0)?
+                        .get_str()?
+                        .to_string();
+                    let library_folder = PathBuf::from(library_folder_string).join("steamapps");
+                    Some(library_folder)
+                })
+                .collect();
 
-			self.paths = library_folders;
-		}
+            self.paths = library_folders;
+        }
 
-		self.discovered = true;
+        self.discovered = true;
 
-		Some(())
-	}
+        Some(())
+    }
 }

--- a/src/steamapp.rs
+++ b/src/steamapp.rs
@@ -19,65 +19,67 @@ use std::path::PathBuf;
 /// ```
 #[derive(Debug, Clone)]
 pub struct SteamApp {
-	/// The app ID of this Steam app.
-	pub appid: u32,
+    /// The app ID of this Steam app.
+    pub appid: u32,
 
-	/// The path to the installation directory of this Steam app.
-	///
-	/// Example: `C:\Program Files (x86)\Steam\steamapps\common\GarrysMod`
-	pub path: PathBuf,
+    /// The path to the installation directory of this Steam app.
+    ///
+    /// Example: `C:\Program Files (x86)\Steam\steamapps\common\GarrysMod`
+    pub path: PathBuf,
 
-	/// A [steamy_vdf::Table](https://docs.rs/steamy-vdf/*/steamy_vdf/struct.Table.html)
-	pub vdf: steamy_vdf::Table,
+    /// A [steamy_vdf::Table](https://docs.rs/steamy-vdf/*/steamy_vdf/struct.Table.html)
+    pub vdf: steamy_vdf::Table,
 
-	/// The store name of the Steam app.
-	pub name: Option<String>,
+    /// The store name of the Steam app.
+    pub name: Option<String>,
 
-	#[cfg(not(feature="steamid_ng"))]
-	/// The SteamID64 of the last Steam user that played this game on the filesystem.
-	///
-	/// This crate supports [steamid-ng](https://docs.rs/steamid-ng) and can automatically convert this to a [SteamID](https://docs.rs/steamid-ng/*/steamid_ng/struct.SteamID.html) for you.
-	///
-	/// To enable this support, [use the  `steamid_ng` Cargo.toml feature](https://docs.rs/steamlocate/*/steamlocate#using-steamlocate).
-	pub last_user: Option<u64>,
+    #[cfg(not(feature = "steamid_ng"))]
+    /// The SteamID64 of the last Steam user that played this game on the filesystem.
+    ///
+    /// This crate supports [steamid-ng](https://docs.rs/steamid-ng) and can automatically convert this to a [SteamID](https://docs.rs/steamid-ng/*/steamid_ng/struct.SteamID.html) for you.
+    ///
+    /// To enable this support, [use the  `steamid_ng` Cargo.toml feature](https://docs.rs/steamlocate/*/steamlocate#using-steamlocate).
+    pub last_user: Option<u64>,
 
-	#[cfg(feature="steamid_ng")]
-	/// The [SteamID](https://docs.rs/steamid-ng/*/steamid_ng/struct.SteamID.html) of the last Steam user that played this game on the filesystem.
-	pub last_user: Option<steamid_ng::SteamID>
+    #[cfg(feature = "steamid_ng")]
+    /// The [SteamID](https://docs.rs/steamid-ng/*/steamid_ng/struct.SteamID.html) of the last Steam user that played this game on the filesystem.
+    pub last_user: Option<steamid_ng::SteamID>,
 }
 
 impl SteamApp {
-	pub(crate) fn new(steamapps: &PathBuf, vdf: &steamy_vdf::Table) -> Option<SteamApp> {
-		// First check if the installation path exists and is a valid directory
-		let install_dir = steamapps.join(vdf.get("installdir")?.as_str()?);
-		if !install_dir.is_dir() { return None }
+    pub(crate) fn new(steamapps: &PathBuf, vdf: &steamy_vdf::Table) -> Option<SteamApp> {
+        // First check if the installation path exists and is a valid directory
+        let install_dir = steamapps.join(vdf.get("installdir")?.as_str()?);
+        if !install_dir.is_dir() {
+            return None;
+        }
 
-		Some(SteamApp {
-			vdf: vdf.clone(),
-			path: install_dir,
+        Some(SteamApp {
+            vdf: vdf.clone(),
+            path: install_dir,
 
-			// Get the appid key, try and parse it as an unsigned 32-bit integer, if we fail, return None
-			appid: vdf.get("appid")?.as_value()?.parse::<u32>().ok()?,
+            // Get the appid key, try and parse it as an unsigned 32-bit integer, if we fail, return None
+            appid: vdf.get("appid")?.as_value()?.parse::<u32>().ok()?,
 
-			// Get the name key, try and convert it into a String, if we fail, name = None
-			name: vdf.get("name").and_then(|entry| entry.as_str().and_then(|str| Some(str.to_string()))),
+            // Get the name key, try and convert it into a String, if we fail, name = None
+            name: vdf
+                .get("name")
+                .and_then(|entry| entry.as_str().and_then(|str| Some(str.to_string()))),
 
-			// Get the LastOwner key, try and convert it into a SteamID64, if we fail, last_user = None
-			#[cfg(not(feature="steamid_ng"))]
-			last_user: vdf.get("LastOwner").and_then(
-				|entry| entry.as_value().and_then(
-					|val| val.parse::<u64>().ok()
-				)
-			),
+            // Get the LastOwner key, try and convert it into a SteamID64, if we fail, last_user = None
+            #[cfg(not(feature = "steamid_ng"))]
+            last_user: vdf
+                .get("LastOwner")
+                .and_then(|entry| entry.as_value().and_then(|val| val.parse::<u64>().ok())),
 
-			#[cfg(feature="steamid_ng")]
-			last_user: vdf.get("LastOwner").and_then(
-				|entry| entry.as_value().and_then(
-					|val| val.parse::<u64>().ok().and_then(
-						|steamid64| Some(steamid_ng::SteamID::from(steamid64))
-					)
-				)
-			),
-		})
-	}
+            #[cfg(feature = "steamid_ng")]
+            last_user: vdf.get("LastOwner").and_then(|entry| {
+                entry.as_value().and_then(|val| {
+                    val.parse::<u64>()
+                        .ok()
+                        .and_then(|steamid64| Some(steamid_ng::SteamID::from(steamid64)))
+                })
+            }),
+        })
+    }
 }

--- a/src/steamapps.rs
+++ b/src/steamapps.rs
@@ -1,78 +1,88 @@
-use crate::steamapp::SteamApp;
 use crate::libraryfolders::LibraryFolders;
+use crate::steamapp::SteamApp;
 use std::collections::HashMap;
 
 #[derive(Default, Clone, Debug)]
 pub(crate) struct SteamApps {
-	pub(crate) apps: HashMap<u32, Option<SteamApp>>,
-	pub(crate) discovered: bool
+    pub(crate) apps: HashMap<u32, Option<SteamApp>>,
+    pub(crate) discovered: bool,
 }
 
 impl SteamApps {
-	pub(crate) fn discover_apps(&mut self, libraryfolders: &LibraryFolders) {
-		self.apps.drain();
+    pub(crate) fn discover_apps(&mut self, libraryfolders: &LibraryFolders) {
+        self.apps.drain();
 
-		for libraryfolder in &libraryfolders.paths {
-			let read_dir = libraryfolder.read_dir();
-			if read_dir.is_err() { continue }
-			for result in read_dir.unwrap() {
-				let file = match result {
-					Err(_) => continue,
-					Ok(file) => file
-				};
+        for libraryfolder in &libraryfolders.paths {
+            let read_dir = libraryfolder.read_dir();
+            if read_dir.is_err() {
+                continue;
+            }
+            for result in read_dir.unwrap() {
+                let file = match result {
+                    Err(_) => continue,
+                    Ok(file) => file,
+                };
 
-				let mut path = file.path();
-				if !path.is_file() { continue }
+                let mut path = file.path();
+                if !path.is_file() {
+                    continue;
+                }
 
-				let app_id: u32 = match file
-					.file_name()
-					.to_str()
-					.and_then(|name| name.strip_prefix("appmanifest_"))
-					.and_then(|prefixless_name| prefixless_name.strip_suffix(".acf"))
-					.and_then(|app_id_str| app_id_str.parse().ok())
-				{
-					Some(app_id) => app_id,
-					None => continue,
-				};
+                let app_id: u32 = match file
+                    .file_name()
+                    .to_str()
+                    .and_then(|name| name.strip_prefix("appmanifest_"))
+                    .and_then(|prefixless_name| prefixless_name.strip_suffix(".acf"))
+                    .and_then(|app_id_str| app_id_str.parse().ok())
+                {
+                    Some(app_id) => app_id,
+                    None => continue,
+                };
 
-				let vdf = match steamy_vdf::load(&path) {
-					Err(_) => continue,
-					Ok(vdf) => match vdf.get("AppState") {
-						None => continue,
-						Some(app_state) => match app_state.as_table() {
-							None => continue,
-							Some(table) => table.to_owned()
-						}
-					}
-				};
+                let vdf = match steamy_vdf::load(&path) {
+                    Err(_) => continue,
+                    Ok(vdf) => match vdf.get("AppState") {
+                        None => continue,
+                        Some(app_state) => match app_state.as_table() {
+                            None => continue,
+                            Some(table) => table.to_owned(),
+                        },
+                    },
+                };
 
-				path.pop(); path.push("common");
+                path.pop();
+                path.push("common");
 
-				self.apps.insert(
-					app_id,
-					SteamApp::new(&path, &vdf)
-				);
-			}
-		}
-	}
+                self.apps.insert(app_id, SteamApp::new(&path, &vdf));
+            }
+        }
+    }
 
-	pub(crate) fn discover_app(&mut self, libraryfolders: &LibraryFolders, app_id: &u32) -> Option<()> {
-		for libraryfolder in &libraryfolders.paths {
-			let mut appmanifest_path = libraryfolder.join(format!("appmanifest_{}.acf", app_id));
-			if appmanifest_path.is_file() {
-				let appmanifest_vdf = steamy_vdf::load(&appmanifest_path).ok()?;
+    pub(crate) fn discover_app(
+        &mut self,
+        libraryfolders: &LibraryFolders,
+        app_id: &u32,
+    ) -> Option<()> {
+        for libraryfolder in &libraryfolders.paths {
+            let mut appmanifest_path = libraryfolder.join(format!("appmanifest_{}.acf", app_id));
+            if appmanifest_path.is_file() {
+                let appmanifest_vdf = steamy_vdf::load(&appmanifest_path).ok()?;
 
-				appmanifest_path.pop(); appmanifest_path.push("common");
+                appmanifest_path.pop();
+                appmanifest_path.push("common");
 
-				self.apps.insert(
-					*app_id,
-					SteamApp::new(&appmanifest_path, appmanifest_vdf.get("AppState")?.as_table()?)
-				);
+                self.apps.insert(
+                    *app_id,
+                    SteamApp::new(
+                        &appmanifest_path,
+                        appmanifest_vdf.get("AppState")?.as_table()?,
+                    ),
+                );
 
-				return Some(())
-			}
-		}
+                return Some(());
+            }
+        }
 
-		None
-	}
+        None
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,79 +9,79 @@ use super::*;
 
 #[test]
 fn find_steam() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
-	println!("{:#?}", steamdir_found.unwrap());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
+    println!("{:#?}", steamdir_found.unwrap());
 }
 
 #[test]
 fn find_library_folders() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
 
-	let mut steamdir = steamdir_found.unwrap();
+    let mut steamdir = steamdir_found.unwrap();
 
-	steamdir.libraryfolders.discover(&steamdir.path);
-	assert!(steamdir.libraryfolders().paths.len() > 1);
+    steamdir.libraryfolders.discover(&steamdir.path);
+    assert!(steamdir.libraryfolders().paths.len() > 1);
 
-	println!("{:#?}", steamdir.libraryfolders.paths);
+    println!("{:#?}", steamdir.libraryfolders.paths);
 }
 
 #[test]
 fn find_app() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
 
-	let mut steamdir = steamdir_found.unwrap();
+    let mut steamdir = steamdir_found.unwrap();
 
-	let steamapp = steamdir.app(&APP_ID);
-	assert!(steamapp.is_some());
+    let steamapp = steamdir.app(&APP_ID);
+    assert!(steamapp.is_some());
 
-	println!("{:#?}", steamapp.unwrap());
+    println!("{:#?}", steamapp.unwrap());
 }
 
 #[test]
 fn app_details() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
 
-	let mut steamdir = steamdir_found.unwrap();
+    let mut steamdir = steamdir_found.unwrap();
 
-	let steamapp = steamdir.app(&APP_ID);
-	assert!(steamapp.is_some());
+    let steamapp = steamdir.app(&APP_ID);
+    assert!(steamapp.is_some());
 
-	assert!(steamapp.unwrap().name.is_some());
-	assert!(steamapp.unwrap().last_user.is_some());
+    assert!(steamapp.unwrap().name.is_some());
+    assert!(steamapp.unwrap().last_user.is_some());
 }
 
 #[test]
 fn all_apps() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
 
-	let mut steamdir = steamdir_found.unwrap();
+    let mut steamdir = steamdir_found.unwrap();
 
-	let steamapps = steamdir.apps();
-	assert!(!steamapps.is_empty());
-	assert!(steamapps.keys().len() > 1);
+    let steamapps = steamdir.apps();
+    assert!(!steamapps.is_empty());
+    assert!(steamapps.keys().len() > 1);
 
-	// println!("{:#?}", steamapps);
+    // println!("{:#?}", steamapps);
 }
 
 #[test]
 fn all_apps_get_one() {
-	let steamdir_found = SteamDir::locate();
-	assert!(steamdir_found.is_some());
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
 
-	let mut steamdir = steamdir_found.unwrap();
+    let mut steamdir = steamdir_found.unwrap();
 
-	let steamapps = steamdir.apps();
-	assert!(!steamapps.is_empty());
-	assert!(steamapps.keys().len() > 1);
+    let steamapps = steamdir.apps();
+    assert!(!steamapps.is_empty());
+    assert!(steamapps.keys().len() > 1);
 
-	let steamapp = steamdir.app(&APP_ID);
-	assert!(steamapp.is_some());
+    let steamapp = steamdir.app(&APP_ID);
+    assert!(steamapp.is_some());
 
-	assert!(steamapp.unwrap().name.is_some());
-	assert!(steamapp.unwrap().last_user.is_some());
+    assert!(steamapp.unwrap().name.is_some());
+    assert!(steamapp.unwrap().last_user.is_some());
 }


### PR DESCRIPTION
I normally have format-on-save on with my editor, so it's easier to send in an initial PR for formatting before followup PRs (easy enough to verify if you just run `cargo fmt` on `master` locally)

I'm finally getting settled in from moving, so I've got time to start working through #7 :tada: