### PR TITLE
Fully switch from `steamy-vdf`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ categories = ["os", "hardware-support", "filesystem", "accessibility"]
 steamid_ng = ["steamid-ng"]
 
 [dependencies]
-steamy-vdf = "0.*.*"
 keyvalues-parser = "0.1"
+keyvalues-serde = "0.1"
+serde = { version = "1.0", features = ["derive"] }
 steamid-ng = { version = "1.*", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/examples/appmanifest.rs
+++ b/examples/appmanifest.rs
@@ -1,0 +1,18 @@
+use std::{env, process::exit};
+
+use steamlocate::SteamDir;
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+    if args.len() != 2 || args[1].parse::<u32>().is_err() {
+        eprintln!("Usage: ./single_app <STEAM_APP_ID>");
+        exit(1);
+    }
+    let app_id: u32 = args[1].parse().unwrap();
+
+    let mut steamdir = SteamDir::locate().unwrap();
+    match steamdir.app(&app_id) {
+        Some(app) => println!("Found app - {:#?}", app),
+        None => println!("No app found for {}", app_id),
+    }
+}

--- a/src/steamapps.rs
+++ b/src/steamapps.rs
@@ -17,13 +17,15 @@ impl SteamApps {
             if read_dir.is_err() {
                 continue;
             }
+
+            let library_base = libraryfolder.clone();
             for result in read_dir.unwrap() {
                 let file = match result {
                     Err(_) => continue,
                     Ok(file) => file,
                 };
 
-                let mut path = file.path();
+                let path = file.path();
                 if !path.is_file() {
                     continue;
                 }
@@ -39,21 +41,8 @@ impl SteamApps {
                     None => continue,
                 };
 
-                let vdf = match steamy_vdf::load(&path) {
-                    Err(_) => continue,
-                    Ok(vdf) => match vdf.get("AppState") {
-                        None => continue,
-                        Some(app_state) => match app_state.as_table() {
-                            None => continue,
-                            Some(table) => table.to_owned(),
-                        },
-                    },
-                };
-
-                path.pop();
-                path.push("common");
-
-                self.apps.insert(app_id, SteamApp::new(&path, &vdf));
+                self.apps
+                    .insert(app_id, SteamApp::new(&library_base, &path));
             }
         }
     }
@@ -64,20 +53,10 @@ impl SteamApps {
         app_id: &u32,
     ) -> Option<()> {
         for libraryfolder in &libraryfolders.paths {
-            let mut appmanifest_path = libraryfolder.join(format!("appmanifest_{}.acf", app_id));
+            let appmanifest_path = libraryfolder.join(format!("appmanifest_{}.acf", app_id));
             if appmanifest_path.is_file() {
-                let appmanifest_vdf = steamy_vdf::load(&appmanifest_path).ok()?;
-
-                appmanifest_path.pop();
-                appmanifest_path.push("common");
-
-                self.apps.insert(
-                    *app_id,
-                    SteamApp::new(
-                        &appmanifest_path,
-                        appmanifest_vdf.get("AppState")?.as_table()?,
-                    ),
-                );
+                self.apps
+                    .insert(*app_id, SteamApp::new(&libraryfolder, &appmanifest_path));
 
                 return Some(());
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,16 +42,9 @@ fn find_app() {
 
 #[test]
 fn app_details() {
-    let steamdir_found = SteamDir::locate();
-    assert!(steamdir_found.is_some());
-
-    let mut steamdir = steamdir_found.unwrap();
-
-    let steamapp = steamdir.app(&APP_ID);
-    assert!(steamapp.is_some());
-
-    assert!(steamapp.unwrap().name.is_some());
-    assert!(steamapp.unwrap().last_user.is_some());
+    let mut steamdir = SteamDir::locate().unwrap();
+    let steamapp = steamdir.app(&APP_ID).unwrap();
+    assert_eq!(steamapp.name, "Garry's Mod");
 }
 
 #[test]
@@ -64,24 +57,15 @@ fn all_apps() {
     let steamapps = steamdir.apps();
     assert!(!steamapps.is_empty());
     assert!(steamapps.keys().len() > 1);
-
-    // println!("{:#?}", steamapps);
 }
 
 #[test]
 fn all_apps_get_one() {
-    let steamdir_found = SteamDir::locate();
-    assert!(steamdir_found.is_some());
-
-    let mut steamdir = steamdir_found.unwrap();
-
+    let mut steamdir = SteamDir::locate().unwrap();
     let steamapps = steamdir.apps();
-    assert!(!steamapps.is_empty());
     assert!(steamapps.keys().len() > 1);
 
-    let steamapp = steamdir.app(&APP_ID);
-    assert!(steamapp.is_some());
+    let steamapp = steamdir.app(&APP_ID).unwrap();
 
-    assert!(steamapp.unwrap().name.is_some());
-    assert!(steamapp.unwrap().last_user.is_some());
+    assert_eq!(steamapp.name, "Garry's Mod");
 }


### PR DESCRIPTION
Fixes #6 

This is the initial work for fully switching from `steamy-vdf`. This is done by using `keyvalues-serde` to convert the entire manifest file into an internal struct that finally gets converted to a `SteamApp` (the whole `InternalSteamApp` -> `SteamApp` was done to accommodate `path` which uses information that is external to the manifest file)

I also decided to add a super basic example to show off the `SteamApp` changes. Here is the result of running it on Inscryption's manifest

```
$ cargo run --example appmanifest -- 1092790
Found app - SteamApp {
    app_id: 1092790,
    path: "/path/to/my/first/library/common/Inscryption",
    name: "Inscryption",
    universe: 1,
    state_flags: 4,
    last_updated: 1650903140,
    update_result: 0,
    size_on_disk: 3513686670,
    build_id: 8386576,
    bytes_to_download: 64990864,
    bytes_downloaded: 64990864,
    bytes_to_stage: 3443365760,
    bytes_staged: 3443365760,
    staging_size: None,
    auto_update_behavior: 0,
    allow_other_downloads_while_running: 0,
    scheduled_auto_update: 0,
    installed_depots: {
        1092791: Depot {
            manifest: 4877467984383706702,
            size: 3513686670,
        },
    },
    user_config: {
        "language": "english",
        "platform_override_dest": "linux",
        "platform_override_source": "windows",
    },
    mounted_config: {},
    install_scripts: {},
    shared_depots: {
        228990: 228980,
    },
    last_user: 12312312312312312,
}
```

## Follow-up work

- I'm not at all confident that these are all the fields possible in a manifest file, so I'll be going through my full steam library to harvest manifest files
- Be more user friendly! I'm planning on parsing a lot of the values into nicer types (`universe`, `auto_update_behavior`, etc. to enums, `state_flags` to a bitfield, etc.)
    - I was initially going to include that in this PR, but it ended up being quite a lot, so I figured 2 smaller PRs was better
    - I found some scattered info on what some of the values mean, but haven't found anything comprehensive sadly ;-;