### PR TITLE
add method to query configured compatibility tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ steamid_ng = ["steamid-ng"]
 [dependencies]
 steamy-vdf = "0.2"
 keyvalues-parser = "0.1"
+serde = { version = "1.0.0", features = ["derive"] }
+keyvalues-serde = "0.1"
 
 crc = { version = "3.0", optional = true }
 

--- a/src/steamcompat.rs
+++ b/src/steamcompat.rs
@@ -1,0 +1,57 @@
+use std::{fs, path::Path};
+
+use keyvalues_serde::from_str;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, Debug)]
+pub struct Store {
+    #[serde(rename = "Software")]
+    pub software: Software,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Software {
+    #[serde(rename = "Valve")]
+    pub valve: Valve,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Valve {
+    #[serde(rename = "Steam")]
+    pub steam: Steam,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Steam {
+    #[serde(rename = "CompatToolMapping")]
+    pub mapping: HashMap<String, SteamCompat>,
+}
+
+/// An instance of a compatibility tool.
+#[derive(Deserialize, Debug, Clone)]
+pub struct SteamCompat {
+    /// The name of the tool.
+    ///
+    /// Example: `proton_411`
+    pub name: Option<String>,
+
+    // Unknown option, may be used in the future
+    pub config: Option<String>,
+
+    // Unknown option, may be used in the future
+    pub priority: Option<u64>,
+}
+
+impl SteamCompat {
+    pub(crate) fn new(steamdir: &Path, app_id: &u32) -> Option<SteamCompat> {
+        let steamdir_config_path = steamdir.join("config").join("config.vdf");
+
+        let vdf_text = fs::read_to_string(&steamdir_config_path).ok()?;
+        let root: Store = from_str(&vdf_text).unwrap();
+
+        let app_id_str: &str = &app_id.to_string();
+
+        return Some(root.software.valve.steam.mapping.get(app_id_str)?.clone());
+    }
+}

--- a/src/steamcompats.rs
+++ b/src/steamcompats.rs
@@ -1,0 +1,15 @@
+use crate::steamcompat::SteamCompat;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Default, Clone, Debug)]
+pub(crate) struct SteamCompats {
+    pub(crate) tools: HashMap<u32, Option<SteamCompat>>,
+}
+
+impl SteamCompats {
+    pub(crate) fn discover_tool(&mut self, steamdir: &Path, app_id: &u32) {
+        self.tools
+            .insert(*app_id, SteamCompat::new(steamdir, app_id));
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -85,3 +85,16 @@ fn all_apps_get_one() {
     assert!(steamapp.unwrap().name.is_some());
     assert!(steamapp.unwrap().last_user.is_some());
 }
+
+#[test]
+fn find_compatibility_tool() {
+    let steamdir_found = SteamDir::locate();
+    assert!(steamdir_found.is_some());
+
+    let mut steamdir = steamdir_found.unwrap();
+
+    let tool = steamdir.compat_tool(&APP_ID);
+    assert!(tool.is_some());
+
+    println!("{:#?}", tool.unwrap());
+}


### PR DESCRIPTION
A better solution would be adding a `tool` attribute to `SteamApp`, but that would require the steam path to be passed, changing the interface.

For the sake of compatibility this adds a new interface that can be queried.

`keyvalues-parser` was used over `steamy-vdf` because steamy does not correctly implement the VDF format and is unable to parse `config.vdf`.