### PR TITLE
Add snap support for linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,8 @@ use winreg::{
 // TODO: shouldn't be needed?
 #[cfg(not(target_os = "windows"))]
 extern crate dirs;
+#[cfg(target_os = "linux")]
+use std::env;
 
 // TODO: rework all of these re-exports
 // TODO: keep these errors in a separate module
@@ -269,6 +271,10 @@ impl SteamDir {
     fn locate_steam_dir() -> Option<PathBuf> {
         // Steam's installation location is pretty easy to find on Linux, too, thanks to the symlink in $USER
         let home_dir = dirs::home_dir()?;
+        let snap_dir = match env::var("SNAP_USER_DATA") {
+            Ok(snap_dir) => PathBuf::from(snap_dir),
+            Err(_) => home_dir.join("snap"),
+        };
 
         let steam_paths = vec![
             // Flatpak steam install directories
@@ -280,6 +286,10 @@ impl SteamDir {
             home_dir.join(".steam/steam"),
             home_dir.join(".steam/root"),
             home_dir.join(".steam"),
+            // Snap steam install directories
+            snap_dir.join("steam/common/.local/share/Steam"),
+            snap_dir.join("steam/common/.steam/steam"),
+            snap_dir.join("steam/common/.steam/root"),
         ];
 
         steam_paths.into_iter().find(|x| x.is_dir())


### PR DESCRIPTION
Steam exists on snap! (unsure if in an official capacity, but its packaged by Canonical).

I put the code after the generic `$HOME/.steam/steam` check, because in the small testing I did Proton was completely unusable so any other released should be preferred.

