### PR TITLE
Add additional Steam search paths for Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,6 @@ impl SteamDir {
             home_dir.join(".var/app/com.valvesoftware.Steam/.local/share/Steam"),
             home_dir.join(".var/app/com.valvesoftware.Steam/.steam/steam"),
             home_dir.join(".var/app/com.valvesoftware.Steam/.steam/root"),
-
             // Standard install directories
             home_dir.join(".local/share/Steam"),
             home_dir.join(".steam/steam"),
@@ -283,8 +282,6 @@ impl SteamDir {
             home_dir.join(".steam"),
         ];
 
-        steam_paths
-            .into_iter()
-            .find(|x| x.is_dir())
+        steam_paths.into_iter().find(|x| x.is_dir())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,21 +270,27 @@ impl SteamDir {
         // Steam's installation location is pretty easy to find on Linux, too, thanks to the symlink in $USER
         let home_dir = dirs::home_dir()?;
 
-        // Check for Flatpak steam install
-        let steam_flatpak_path = home_dir.join(".var/app/com.valvesoftware.Steam");
-        if steam_flatpak_path.is_dir() {
-            let steam_flatpak_install_path = steam_flatpak_path.join(".steam/steam");
-            if steam_flatpak_install_path.is_dir() {
-                return Some(steam_flatpak_install_path);
-            }
-        }
+        let steam_paths = vec![
+            // Flatpak steam install directories
+            home_dir.join(".var/app/com.valvesoftware.Steam/.local/share/Steam"),
+            home_dir.join(".var/app/com.valvesoftware.Steam/.steam/steam"),
+            home_dir.join(".var/app/com.valvesoftware.Steam/.steam/root"),
 
-        // Check for Standard steam install
-        let standard_path = home_dir.join(".steam/steam");
-        if standard_path.is_dir() {
-            return Some(standard_path);
-        }
+            // Standard install directories
+            home_dir.join(".local/share/Steam"),
+            home_dir.join(".steam/steam"),
+            home_dir.join(".steam/root"),
+            home_dir.join(".steam"),
+        ];
 
-        None
+        match steam_paths
+            .into_iter()
+            .find(|x| x.is_dir()) {
+            Some(path) => Some(SteamDir {
+                path,
+                ..Default::default()
+            }),
+            None => None,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,14 +283,8 @@ impl SteamDir {
             home_dir.join(".steam"),
         ];
 
-        match steam_paths
+        steam_paths
             .into_iter()
-            .find(|x| x.is_dir()) {
-            Some(path) => Some(SteamDir {
-                path,
-                ..Default::default()
-            }),
-            None => None,
-        }
+            .find(|x| x.is_dir())
     }
 }


### PR DESCRIPTION
Quick and easy PR to add support for other Steam install paths. Flatpak still take precedence over native, so dirs that persist after uninstallation may cause problems (issue #17).

I can also add Snap support if needed, however I would rather not obstruct the work done in PR #30.

