### PR TITLE
App IDs are u32 and don't need to be references

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ extern crate steamlocate;
 use steamlocate::SteamDir;
 
 let mut steamdir = SteamDir::locate().unwrap();
-match steamdir.app(&4000) {
+match steamdir.app(4000) {
 	Some(app) => println!("{:#?}", app),
 	None => panic!("Couldn't locate Garry's Mod on this computer!")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! use steamlocate::SteamDir;
 //!
 //! let mut steamdir = SteamDir::locate().unwrap();
-//! match steamdir.app(&4000) {
+//! match steamdir.app(4000) {
 //!     Some(app) => println!("{:#?}", app),
 //!     None => panic!("Couldn't locate Garry's Mod on this computer!")
 //! }
@@ -239,7 +239,7 @@ impl SteamDir {
     /// ```rust
     /// # use steamlocate::SteamDir;
     /// let mut steamdir = SteamDir::locate().unwrap();
-    /// let gmod = steamdir.app(&4000);
+    /// let gmod = steamdir.app(4000);
     /// println!("{:#?}", gmod.unwrap());
     /// ```
     /// ```ignore
@@ -251,10 +251,10 @@ impl SteamDir {
     ///     last_user: Some(u64: 76561198040894045) // This will be a steamid_ng::SteamID if the "steamid_ng" feature is enabled
     /// )
     /// ```
-    pub fn app(&mut self, app_id: &u32) -> Option<&SteamApp> {
+    pub fn app(&mut self, app_id: u32) -> Option<&SteamApp> {
         let steam_apps = &mut self.steam_apps;
 
-        if !steam_apps.apps.contains_key(app_id) {
+        if !steam_apps.apps.contains_key(&app_id) {
             let libraryfolders = &mut self.libraryfolders;
             if !libraryfolders.discovered {
                 libraryfolders.discover(&self.path);
@@ -262,7 +262,7 @@ impl SteamDir {
             steam_apps.discover_app(libraryfolders, app_id);
         }
 
-        steam_apps.apps.get(app_id).and_then(|app| app.as_ref())
+        steam_apps.apps.get(&app_id).and_then(|app| app.as_ref())
     }
 
     /// Returns a `Some` reference to a `SteamCompat` via its app ID.
@@ -270,16 +270,16 @@ impl SteamDir {
     /// If no compatibility tool is configured for the app, this will return `None`.
     ///
     /// This function will cache its (either `Some` and `None`) result and will always return a reference to the same `SteamCompat`.
-    pub fn compat_tool(&mut self, app_id: &u32) -> Option<&SteamCompat> {
+    pub fn compat_tool(&mut self, app_id: u32) -> Option<&SteamCompat> {
         let steam_compat = &mut self.steam_compat;
 
-        if !steam_compat.tools.contains_key(app_id) {
+        if !steam_compat.tools.contains_key(&app_id) {
             steam_compat.discover_tool(&self.path, app_id)
         }
 
         steam_compat
             .tools
-            .get(app_id)
+            .get(&app_id)
             .and_then(|compat_tool| compat_tool.as_ref())
     }
 

--- a/src/steamapp.rs
+++ b/src/steamapp.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 /// ```rust
 /// # use steamlocate::SteamDir;
 /// let mut steamdir = SteamDir::locate().unwrap();
-/// let gmod = steamdir.app(&4000);
+/// let gmod = steamdir.app(4000);
 /// println!("{:#?}", gmod.unwrap());
 /// ```
 /// ```ignore

--- a/src/steamapps.rs
+++ b/src/steamapps.rs
@@ -61,7 +61,7 @@ impl SteamApps {
     pub(crate) fn discover_app(
         &mut self,
         libraryfolders: &LibraryFolders,
-        app_id: &u32,
+        app_id: u32,
     ) -> Option<()> {
         for libraryfolder in &libraryfolders.paths {
             let mut appmanifest_path = libraryfolder.join(format!("appmanifest_{}.acf", app_id));
@@ -72,7 +72,7 @@ impl SteamApps {
                 appmanifest_path.push("common");
 
                 self.apps.insert(
-                    *app_id,
+                    app_id,
                     SteamApp::new(
                         &appmanifest_path,
                         appmanifest_vdf.get("AppState")?.as_table()?,

--- a/src/steamcompat.rs
+++ b/src/steamcompat.rs
@@ -44,7 +44,7 @@ pub struct SteamCompat {
 }
 
 impl SteamCompat {
-    pub(crate) fn new(steamdir: &Path, app_id: &u32) -> Option<SteamCompat> {
+    pub(crate) fn new(steamdir: &Path, app_id: u32) -> Option<SteamCompat> {
         let steamdir_config_path = steamdir.join("config").join("config.vdf");
 
         let vdf_text = fs::read_to_string(steamdir_config_path).ok()?;

--- a/src/steamcompats.rs
+++ b/src/steamcompats.rs
@@ -8,8 +8,8 @@ pub(crate) struct SteamCompats {
 }
 
 impl SteamCompats {
-    pub(crate) fn discover_tool(&mut self, steamdir: &Path, app_id: &u32) {
+    pub(crate) fn discover_tool(&mut self, steamdir: &Path, app_id: u32) {
         self.tools
-            .insert(*app_id, SteamCompat::new(steamdir, app_id));
+            .insert(app_id, SteamCompat::new(steamdir, app_id));
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,10 +34,10 @@ fn find_app() {
 
     let mut steamdir = steamdir_found.unwrap();
 
-    let steamapp = steamdir.app(&APP_ID);
+    let steamapp = steamdir.app(APP_ID);
     assert!(steamapp.is_some());
 
-    assert!(steamdir.app(&u32::MAX).is_none());
+    assert!(steamdir.app(u32::MAX).is_none());
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn app_details() {
 
     let mut steamdir = steamdir_found.unwrap();
 
-    let steamapp = steamdir.app(&APP_ID);
+    let steamapp = steamdir.app(APP_ID);
     assert!(steamapp.is_some());
 
     assert!(steamapp.unwrap().name.is_some());
@@ -79,7 +79,7 @@ fn all_apps_get_one() {
     assert!(!steamapps.is_empty());
     assert!(steamapps.keys().len() > 1);
 
-    let steamapp = steamdir.app(&APP_ID);
+    let steamapp = steamdir.app(APP_ID);
     assert!(steamapp.is_some());
 
     assert!(steamapp.unwrap().name.is_some());
@@ -93,7 +93,7 @@ fn find_compatibility_tool() {
 
     let mut steamdir = steamdir_found.unwrap();
 
-    let tool = steamdir.compat_tool(&APP_ID);
+    let tool = steamdir.compat_tool(APP_ID);
     assert!(tool.is_some());
 
     println!("{:#?}", tool.unwrap());


### PR DESCRIPTION
App IDs are u32 and don't need to be references except when storing in collections