### PR TITLE
My steam installation has only one library dir (Ubuntu 23.04)

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,7 +22,7 @@ fn find_library_folders() {
     let mut steamdir = steamdir_found.unwrap();
 
     steamdir.libraryfolders.discover(&steamdir.path);
-    assert!(steamdir.libraryfolders().paths.len() > 1);
+    assert!(!steamdir.libraryfolders().paths.is_empty(), "at least one library folder expected");
 
     println!("{:#?}", steamdir.libraryfolders.paths);
 }


### PR DESCRIPTION
Fixes a failing test that assumes more than one library dir