### PR TITLE
Drastically simplify test helpers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,11 +150,9 @@ pub use libraryfolders::{parse_library_folders, Library};
 pub mod shortcut;
 pub use shortcut::Shortcut;
 
-/// NOT A PART OF THE PUBLIC API
-///
 /// These are just some helpers for setting up dummy test environments
-#[doc(hidden)]
-pub mod __test_helpers;
+#[cfg(any(test, doctest))]
+pub mod test_helpers;
 
 /// An instance of a Steam installation.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto;
 
 use crate::{
+    test_helpers::{SampleApp, TempSteamDir, TestError, TestResult},
     Error,
-    __test_helpers::{SampleApp, TempSteamDir, TestError, TestResult, TestTempDir},
 };
 
 static GMOD_ID: u32 = SampleApp::GarrysMod.id();
@@ -11,7 +11,7 @@ static GMOD_ID: u32 = SampleApp::GarrysMod.id();
 // - Steam must be installed
 // - At least two library folders must be setup (the steam dir acts as one)
 // - Garry's Mod along with at least one other steam app must be installed
-pub fn legacy_test_env() -> std::result::Result<TempSteamDir<TestTempDir>, TestError> {
+pub fn legacy_test_env() -> std::result::Result<TempSteamDir, TestError> {
     TempSteamDir::builder()
         .app(SampleApp::GarrysMod.into())
         .library(SampleApp::GraveyardKeeper.try_into()?)


### PR DESCRIPTION
On further thought the juice doesn't seem worth the squeeze. The bulk of the complexity was providing helpers that would work with integration tests. We can just stick to unit tests and doc tests instead. It's simple enough to treat unit tests as integration tests anyways