### PR TITLE
Run `cargo test` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  test:
+    needs: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check formatting
+        run: cargo test
+
   docs:
     needs: fmt
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! # Examples
 //!
 //! ### Locate the installed Steam directory
-//! ```rust
+//! ```rust,ignore
 //! extern crate steamlocate;
 //! use steamlocate::SteamDir;
 //!
@@ -161,7 +161,7 @@ pub mod test_helpers;
 /// If you'd like to dispose of the cache or get uncached results, just instantiate a new `SteamDir`.
 ///
 /// # Example
-/// ```rust
+/// ```rust,ignore
 /// # use steamlocate::SteamDir;
 /// let steamdir = SteamDir::locate();
 /// println!("{:#?}", steamdir.unwrap());


### PR DESCRIPTION
Now that tests are switched to use isolated dummy steam installations we can actually test stuff in CI :tada: 