### PR TITLE
Run CI on more platforms/channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, beta]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain
+      - name: Install ${{ matrix.toolchain }} toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
       - name: Setup cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rustfmt
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
       - name: Commune with clippy
         run: cargo clippy --all -- -D warnings
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,35 +10,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
+  validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Clippy
+      - name: Commune with clippy
         run: cargo clippy --all -- -D warnings
-
-  fmt:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
       - name: Check formatting
         run: cargo fmt --all -- --check
-
-  test:
-    needs: fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Check formatting
+      - name: Run test suite
         run: cargo test
-
-  docs:
-    needs: fmt
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - uses: actions/checkout@v3
       - name: Check docs
+        env:
+          RUSTDOCFLAGS: -Dwarnings
         run: cargo doc --all --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
       - name: Commune with clippy
         run: cargo clippy --all -- -D warnings
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ env:
 
 jobs:
   validation:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Commune with clippy


### PR DESCRIPTION
This switches CI to run on all the platforms that we have `cfg`s for along with checking against both the stable and beta toolchains to try and catch issues earlier when possible