### PR TITLE
Expose `Library::from_dir()` and `InstallDir::library_paths()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,9 +172,14 @@ impl InstallDir {
         &self.path
     }
 
-    pub fn libraries(&self) -> Result<library::Iter> {
+    pub fn library_paths(&self) -> Result<Vec<PathBuf>> {
         let libraryfolders_vdf = self.path.join("steamapps").join("libraryfolders.vdf");
-        library::parse_library_folders(&libraryfolders_vdf)
+        library::parse_library_paths(&libraryfolders_vdf)
+    }
+
+    pub fn libraries(&self) -> Result<library::Iter> {
+        let paths = self.library_paths()?;
+        Ok(library::Iter::new(paths))
     }
 
     /// Returns a `Some` reference to a `App` via its app ID.

--- a/src/library.rs
+++ b/src/library.rs
@@ -84,7 +84,7 @@ impl Iterator for Iter {
     type Item = Result<Library>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.paths.next().map(Library::new)
+        self.paths.next().map(|path| Library::from_dir(&path))
     }
 }
 
@@ -101,7 +101,7 @@ pub struct Library {
 }
 
 impl Library {
-    fn new(path: PathBuf) -> Result<Self> {
+    pub fn from_dir(path: &Path) -> Result<Self> {
         // Read the manifest files at the library to get an up-to-date list of apps since the
         // values in `libraryfolders.vdf` may be stale
         let mut apps = Vec::new();
@@ -119,7 +119,10 @@ impl Library {
             }
         }
 
-        Ok(Self { path, apps })
+        Ok(Self {
+            path: path.to_owned(),
+            apps,
+        })
     }
 
     pub fn path(&self) -> &Path {

--- a/src/library.rs
+++ b/src/library.rs
@@ -42,7 +42,7 @@ use keyvalues_parser::Vdf;
 ///     ...
 /// }
 /// ```
-pub(crate) fn parse_library_folders(path: &Path) -> Result<Iter> {
+pub(crate) fn parse_library_paths(path: &Path) -> Result<Vec<PathBuf>> {
     let parse_error = |err| Error::parse(ParseErrorKind::LibraryFolders, err, path);
 
     if !path.is_file() {
@@ -71,13 +71,19 @@ pub(crate) fn parse_library_folders(path: &Path) -> Result<Iter> {
         })
         .collect::<Result<_>>()?;
 
-    Ok(Iter {
-        paths: paths.into_iter(),
-    })
+    Ok(paths)
 }
 
 pub struct Iter {
     paths: std::vec::IntoIter<PathBuf>,
+}
+
+impl Iter {
+    pub(crate) fn new(paths: Vec<PathBuf>) -> Self {
+        Self {
+            paths: paths.into_iter(),
+        }
+    }
 }
 
 impl Iterator for Iter {


### PR DESCRIPTION
Relevant context https://github.com/WilliamVenner/steamlocate-rs/issues/48#issuecomment-1833309059

This exposes `Library::from_dir()` which allows for constructing a library from an arbitrary directory like the new `InstallDir::from_steam_dir()` along with adding a way to get the full listing of library paths from an `InstallDir`. This makes `InstallDir::libraries` a trivial combination of the two :)