### PR TITLE
Remove need to use `tempfile`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "steamlocate_doctest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["os", "hardware-support", "filesystem", "accessibility"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "steamlocate_doctest"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 # TODO: test more features in CI
 
@@ -26,10 +26,6 @@ keyvalues-parser = "0.2"
 keyvalues-serde = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 
-# Custom cfg used to enable a dependency only needed for doctests
-[target."cfg(steamlocate_doctest)".dependencies]
-tempfile = "3.8.1"
-
 # Platform-specific dependencies used for locating the steam dir
 [target."cfg(target_os=\"windows\")".dependencies]
 locate_backend = { package = "winreg", version = "0.51", optional = true }
@@ -38,4 +34,3 @@ locate_backend = { package = "dirs", version = "5", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["ron"] }
-tempfile = "3.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steamlocate"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["William Venner <william@venner.io>"]
 edition = "2018"
 repository = "https://github.com/WilliamVenner/steamlocate-rs"

--- a/src/tests/legacy.rs
+++ b/src/tests/legacy.rs
@@ -1,5 +1,3 @@
-// TODO: steamlocate_tempfile cfg for docs. Otherwise rely on a env var to get passed in
-
 use crate::{
     tests::{
         helpers::{expect_test_env, SampleApp},


### PR DESCRIPTION
The beta push failed to build docs because of a missing `tempfile` dependency. I tried replicating the failure, but it seems like docs.rs just ignores that extra `cfg(steamlocate_doctest)` dependency

I got tired of dealing with the headache since everything seems to work fine locally. We don't use much from `tempfile`, so it's easy enough to provide our own