### PR TITLE
Add a basic dependabot flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds a dependabot flow to handle updating our github actions actions since it's very easy to accidentally let those get out of date

This should also eventually fix the current CI warnings about outdated actions