### PR TITLE
refactor: Update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "steamlocate"
 version = "2.0.0-beta.2"
 authors = ["William Venner <william@venner.io>"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/WilliamVenner/steamlocate-rs"
 license = "MIT"
 description = "Rust Crate for locating Steam game installation directories (and Steam itself!)"

--- a/src/__private_tests/helpers.rs
+++ b/src/__private_tests/helpers.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::BTreeMap,
-    convert::{TryFrom, TryInto},
     fs, iter,
     path::{Path, PathBuf},
 };


### PR DESCRIPTION
Our MSRV is already past the 2021 edition, so no reason to stay on the 2018 edition