### PR TITLE
refactor: Swtich `Shortcut::steam_id` from a field to a method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,5 @@
 root = true
 
-[*]
-indent_style = tab
-indent_size = 4
-charset = utf-8
-trim_trailing_whitespace = true
-
 [*.yml]
 indent_style = space
 indent_size = 2

--- a/src/shortcut.rs
+++ b/src/shortcut.rs
@@ -31,33 +31,32 @@ pub struct Shortcut {
     pub executable: String,
     /// The directory that the application should be run in
     pub start_dir: String,
-    /// The shortcut's Steam ID calculated from the executable path and app name
-    pub steam_id: u64,
 }
 
 impl Shortcut {
     /// Calculates the shortcut's Steam ID from the executable and app name
     pub fn new(app_id: u32, app_name: String, executable: String, start_dir: String) -> Self {
-        fn calculate_steam_id(executable: &[u8], app_name: &[u8]) -> u64 {
-            let algorithm = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
-
-            let mut digest = algorithm.digest();
-            digest.update(executable);
-            digest.update(app_name);
-
-            let top = digest.finalize() | 0x80000000;
-            ((top as u64) << 32) | 0x02000000
-        }
-
-        let steam_id = calculate_steam_id(executable.as_bytes(), app_name.as_bytes());
-
         Self {
             app_id,
             app_name,
             executable,
             start_dir,
-            steam_id,
         }
+    }
+
+    /// The shortcut's Steam ID calculated from the executable path and app name
+    pub fn steam_id(&self) -> u64 {
+        let executable = self.executable.as_bytes();
+        let app_name = self.app_name.as_bytes();
+
+        let algorithm = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+
+        let mut digest = algorithm.digest();
+        digest.update(executable);
+        digest.update(app_name);
+
+        let top = digest.finalize() | 0x80000000;
+        ((top as u64) << 32) | 0x02000000
     }
 }
 
@@ -237,23 +236,28 @@ mod tests {
                     app_name: "Anki".into(),
                     executable: "\"anki\"".into(),
                     start_dir: "\"./\"".into(),
-                    steam_id: 0xe89614fe02000000,
                 },
                 Shortcut {
                     app_id: 2492174738,
                     app_name: "LibreOffice Calc".into(),
                     executable: "\"libreoffice\"".into(),
                     start_dir: "\"./\"".into(),
-                    steam_id: 0xdb01c79902000000,
                 },
                 Shortcut {
                     app_id: 3703025501,
                     app_name: "foo.sh".into(),
                     executable: "\"/usr/local/bin/foo.sh\"".into(),
                     start_dir: "\"/usr/local/bin/\"".into(),
-                    steam_id: 0x9d55017302000000,
                 }
             ],
+        );
+        let steam_ids: Vec<_> = shortcuts
+            .iter()
+            .map(|shortcut| shortcut.steam_id())
+            .collect();
+        assert_eq!(
+            steam_ids,
+            [0xe89614fe02000000, 0xdb01c79902000000, 0x9d55017302000000,]
         );
 
         let contents = include_bytes!("../tests/sample_data/shortcuts_different_key_case.vdf");
@@ -265,7 +269,6 @@ mod tests {
                 app_name: "Second Life".into(),
                 executable: "\"/Applications/Second Life Viewer.app\"".into(),
                 start_dir: "\"/Applications/\"".into(),
-                steam_id: 0xfdd972df02000000,
             }]
         );
     }


### PR DESCRIPTION
And another commit to get rid of a blanket `.editorconfig` definition that kept messing up my formatting :smiling_imp: 