### PR TITLE
Make tests into integration tests where possible

### DIFF
--- a/src/__private_tests/mod.rs
+++ b/src/__private_tests/mod.rs
@@ -1,11 +1,5 @@
 pub mod helpers;
-#[cfg(test)]
-mod legacy;
 mod temp;
-#[cfg(test)]
-mod tests;
-#[cfg(test)]
-mod wasm;
 
 pub type TestError = Box<dyn std::error::Error>;
 pub type TestResult = Result<(), TestError>;

--- a/tests/legacy.rs
+++ b/tests/legacy.rs
@@ -7,7 +7,7 @@ static GMOD_ID: u32 = SampleApp::GarrysMod.id();
 fn find_library_folders() -> TestResult {
     let tmp_steam_dir = expect_test_env();
     let steam_dir = tmp_steam_dir.steam_dir();
-    assert!(steam_dir.libraries().unwrap().len() > 1);
+    assert!(steam_dir.libraries()?.len() > 1);
     Ok(())
 }
 
@@ -15,7 +15,7 @@ fn find_library_folders() -> TestResult {
 fn find_app() -> TestResult {
     let tmp_steam_dir = expect_test_env();
     let steam_dir = tmp_steam_dir.steam_dir();
-    let steam_app = steam_dir.find_app(GMOD_ID).unwrap();
+    let steam_app = steam_dir.find_app(GMOD_ID)?;
     assert_eq!(steam_app.unwrap().0.app_id, GMOD_ID);
     Ok(())
 }
@@ -33,17 +33,15 @@ fn app_details() -> TestResult {
 fn all_apps() -> TestResult {
     let tmp_steam_dir = expect_test_env();
     let steam_dir = tmp_steam_dir.steam_dir();
-    let mut libraries = steam_dir.libraries().unwrap();
-    let all_apps: Vec<_> = libraries
-        .try_fold(Vec::new(), |mut acc, maybe_library| {
-            let library = maybe_library?;
-            for maybe_app in library.apps() {
-                let app = maybe_app?;
-                acc.push(app);
-            }
-            Ok::<_, Error>(acc)
-        })
-        .unwrap();
+    let mut libraries = steam_dir.libraries()?;
+    let all_apps: Vec<_> = libraries.try_fold(Vec::new(), |mut acc, maybe_library| {
+        let library = maybe_library?;
+        for maybe_app in library.apps() {
+            let app = maybe_app?;
+            acc.push(app);
+        }
+        Ok::<_, Error>(acc)
+    })?;
     assert!(all_apps.len() > 1);
     Ok(())
 }
@@ -53,21 +51,19 @@ fn all_apps_get_one() -> TestResult {
     let tmp_steam_dir = expect_test_env();
     let steam_dir = tmp_steam_dir.steam_dir();
 
-    let mut libraries = steam_dir.libraries().unwrap();
-    let all_apps: Vec<_> = libraries
-        .try_fold(Vec::new(), |mut acc, maybe_library| {
-            let library = maybe_library?;
-            for maybe_app in library.apps() {
-                let app = maybe_app?;
-                acc.push(app);
-            }
-            Ok::<_, Error>(acc)
-        })
-        .unwrap();
+    let mut libraries = steam_dir.libraries()?;
+    let all_apps: Vec<_> = libraries.try_fold(Vec::new(), |mut acc, maybe_library| {
+        let library = maybe_library?;
+        for maybe_app in library.apps() {
+            let app = maybe_app?;
+            acc.push(app);
+        }
+        Ok::<_, Error>(acc)
+    })?;
     assert!(!all_apps.is_empty());
     assert!(all_apps.len() > 1);
 
-    let steam_app = steam_dir.find_app(GMOD_ID).unwrap().unwrap();
+    let steam_app = steam_dir.find_app(GMOD_ID)?.unwrap();
     assert_eq!(
         all_apps
             .into_iter()

--- a/tests/legacy.rs
+++ b/tests/legacy.rs
@@ -1,8 +1,5 @@
-use super::{
-    helpers::{expect_test_env, SampleApp},
-    TestResult,
-};
-use crate::Error;
+use steamlocate::Error;
+use steamlocate::__private_tests::prelude::*;
 
 static GMOD_ID: u32 = SampleApp::GarrysMod.id();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ use steamlocate::__private_tests::prelude::*;
 #[test]
 fn app_lastupdated_casing() -> TestResult {
     let sample_app = SampleApp::Resonite;
-    let temp_steam_dir = TempSteamDir::builder().app(sample_app.into()).finish()?;
+    let temp_steam_dir: TempSteamDir = sample_app.try_into()?;
     let steam_dir = temp_steam_dir.steam_dir();
 
     let (app, _library) = steam_dir.find_app(sample_app.id())?.unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,4 @@
-use super::{
-    helpers::{SampleApp, TempSteamDir},
-    TestResult,
-};
+use steamlocate::__private_tests::prelude::*;
 
 // Context: https://github.com/WilliamVenner/steamlocate-rs/issues/58
 #[test]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -9,5 +9,5 @@ fn locate() {
     #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
     unreachable!("Don't run ignored tests silly");
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    let _ = crate::SteamDir::locate().unwrap_err();
+    let _ = steamlocate::SteamDir::locate().unwrap_err();
 }


### PR DESCRIPTION
If they don't rely on anything internal then there's no point in them being unit tests