### PR TITLE
feat: add debian-installation path to unique steam paths

### DIFF
--- a/src/locate.rs
+++ b/src/locate.rs
@@ -87,6 +87,7 @@ fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
         home_dir.join(".local/share/Steam"),
         home_dir.join(".steam/steam"),
         home_dir.join(".steam/root"),
+        home_dir.join(".steam/debian-installation"),
         // Snap steam install directories
         snap_dir.join("steam/common/.local/share/Steam"),
         snap_dir.join("steam/common/.steam/steam"),


### PR DESCRIPTION
Hello!

I found this project and noticed that it doesn't try to check one specific path that i needed for another project (ALVR) and decided to add it.

This is primarily (probably) used for Linux Mint, but i assume Debian itself also gonna have similar path.