### PR TITLE
feat: add InstallationType exposed to public, refactor locate platform code

### DIFF
--- a/examples/multiple-dirs.rs
+++ b/examples/multiple-dirs.rs
@@ -4,6 +4,10 @@ fn main() {
     let steamdir = steamlocate::SteamDir::locate_multiple().unwrap();
     println!("Dirs:");
     for dir in steamdir {
-        println!("{}", dir.path().to_str().unwrap_or_default())
+        println!(
+            "{:?} : {}",
+            dir.installation_type(),
+            dir.path().to_str().unwrap_or_default()
+        )
     }
 }

--- a/src/__private_tests/helpers.rs
+++ b/src/__private_tests/helpers.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use super::{temp::TempDir, TestError};
-use crate::SteamDir;
+use crate::{locate::InstallationType, SteamDir};
 
 use serde_derive::Serialize;
 
@@ -66,6 +66,7 @@ pub struct TempSteamDirBuilder {
     shortcuts: Option<SampleShortcuts>,
     libraries: Vec<TempLibrary>,
     apps: Vec<AppFile>,
+    installation_type: InstallationType,
 }
 
 impl TempSteamDirBuilder {
@@ -84,12 +85,18 @@ impl TempSteamDirBuilder {
         self
     }
 
+    pub fn installation_type(mut self, installation_type: InstallationType) -> Self {
+        self.installation_type = installation_type;
+        self
+    }
+
     // Steam dir is also a library, but is laid out slightly differently than a regular library
     pub fn finish(self) -> Result<TempSteamDir, TestError> {
         let Self {
             shortcuts,
             libraries,
             apps,
+            installation_type,
         } = self;
 
         let tmp = TempDir::new()?;
@@ -119,7 +126,7 @@ impl TempSteamDirBuilder {
             .collect();
 
         Ok(TempSteamDir {
-            steam_dir: SteamDir::from_dir(&steam_dir)?,
+            steam_dir: SteamDir::from_dir(&steam_dir, &installation_type)?,
             _tmps: tmps,
         })
     }

--- a/src/locate/macos.rs
+++ b/src/locate/macos.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use crate::Result;
+use crate::{locate::InstallationType, Result};
 
-pub fn locate_steam_dir_helper() -> Result<PathBuf> {
+pub fn locate_steam_dir_helper() -> Result<(PathBuf, InstallationType)> {
     use crate::{error::LocateError, Error};
     // Steam's installation location is pretty easy to find on macOS, as it's always in
     // $USER/Library/Application Support
@@ -10,5 +10,5 @@ pub fn locate_steam_dir_helper() -> Result<PathBuf> {
 
     // Find Library/Application Support/Steam
     let install_path = home_dir.join("Library/Application Support/Steam");
-    Ok(install_path)
+    Ok((install_path, InstallationType::MacosStandard))
 }

--- a/src/locate/mod.rs
+++ b/src/locate/mod.rs
@@ -15,17 +15,27 @@ mod macos;
 #[cfg(target_os = "macos")]
 use crate::locate::macos::locate_steam_dir_helper;
 
+#[derive(Clone, Debug, Default)]
+pub enum InstallationType {
+    LinuxStandard,
+    LinuxFlatpak,
+    LinuxSnap,
+    MacosStandard,
+    #[default]
+    WindowsStandard,
+}
+
 #[cfg(target_os = "linux")]
-pub fn locate_steam_dir() -> Result<Vec<std::path::PathBuf>> {
+pub fn locate_steam_dir() -> Result<Vec<(std::path::PathBuf, InstallationType)>> {
     locate_steam_dir_helper()
 }
 #[cfg(not(target_os = "linux"))]
-pub fn locate_steam_dir() -> Result<Vec<std::path::PathBuf>> {
+pub fn locate_steam_dir() -> Result<Vec<(std::path::PathBuf, InstallationType)>> {
     locate_steam_dir_helper().map(|path| vec![path])
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-fn locate_steam_dir_helper() -> Result<std::path::PathBuf> {
+fn locate_steam_dir_helper() -> Result<(std::path::PathBuf, InstallationType)> {
     use crate::error::{Error, LocateError};
     Err(Error::locate(LocateError::Unsupported))
 }

--- a/src/locate/windows.rs
+++ b/src/locate/windows.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use crate::Result;
+use crate::{locate::InstallationType, Result};
 
-pub fn locate_steam_dir_helper() -> Result<PathBuf> {
+pub fn locate_steam_dir_helper() -> Result<(PathBuf, InstallationType)> {
     use crate::error::{Error, LocateError};
 
     use winreg::{
@@ -31,5 +31,5 @@ pub fn locate_steam_dir_helper() -> Result<PathBuf> {
         .map_err(io_to_locate_err)?;
 
     let install_path = PathBuf::from(install_path_str);
-    Ok(install_path)
+    Ok((install_path, InstallationType::WindowsStandard))
 }


### PR DESCRIPTION
Hello again from ALVR!

It seems like just adding new directory to search path wasn't exactly enough, because even though we could find directories - we would need to identify which type are they (and then select accordingly, depending from where our app would run)

So i refactored platform code for locate into module with separate files (seemed like a reasonable thing to do) and added InstallationType

I wasn't exactly sure how to make it properly, because when i first tried if-gating everything, it was a complete mess, so i decided to add generic enum for all platforms instead. Code looks much cleaner, even though other platforms (windows, macos) don't have alternative option. Please share your opinion on this, as there might be cleaner way to do it for linux than this.
