### PR TITLE
Improved locate_steam_dir_helper selection criteria for linux

### DIFF
--- a/src/locate/linux.rs
+++ b/src/locate/linux.rs
@@ -31,7 +31,7 @@ pub fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
         snap_dir.join("steam/common/.steam/root"),
     ]
     .into_iter()
-    .filter(|path| path.is_dir() && path.join("steamapps").is_dir())
+    .filter(|path| path.join("steamapps").is_dir())
     .filter_map(|path| {
         let resolved_path = path.read_link().unwrap_or_else(|_| path.clone());
         path_deduper.insert(resolved_path.clone()).then_some(path)

--- a/src/locate/linux.rs
+++ b/src/locate/linux.rs
@@ -31,7 +31,7 @@ pub fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
         snap_dir.join("steam/common/.steam/root"),
     ]
     .into_iter()
-    .filter(|path| path.is_dir())
+    .filter(|path| path.is_dir() && path.join("steamapps").is_dir())
     .filter_map(|path| {
         let resolved_path = path.read_link().unwrap_or_else(|_| path.clone());
         path_deduper.insert(resolved_path.clone()).then_some(path)


### PR DESCRIPTION
The Steam installation in Linux Mint 22.2 creates multiple directories that might be considered to hold the actual steam installation. This patch fixes the selection criteria so that the functions (mainly `libraries()`) called on a SteamDir struct work as expected.

I only make this change to linux beacuse its the only target I can test and it fixes a very specific problem of a program that I use that depends on this crate.