### PR TITLE
deps: `wasm-bindgen-test` only needed on `wasm`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ winreg = "0.56.0"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["ron"] }
-# TODO: make target specific
+
+[target."cfg(not(any(target_os=\"windows\", target_os=\"macos\", target_os=\"linux\")))".dev-dependencies]
 wasm-bindgen-test = "0.3.39"

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,13 +1,6 @@
-use wasm_bindgen_test::wasm_bindgen_test;
-
-#[wasm_bindgen_test]
-#[cfg_attr(
-    not(any(target_os = "windows", target_os = "macos", target_os = "linux")),
-    ignore = "Needs `locate` feature"
-)]
+// TODO: add tests that we can load a steam install using `::from_dir()`
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn locate() {
-    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-    unreachable!("Don't run ignored tests silly");
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     let _ = steamlocate::locate().unwrap_err();
 }


### PR DESCRIPTION
less dependencies when testing on non-wasm :tada: