### PR TITLE
Look for Steam in `XDG_DATA_HOME` on Linux

### DIFF
--- a/src/locate/linux.rs
+++ b/src/locate/linux.rs
@@ -8,6 +8,9 @@ pub fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
     let snap_dir = env::var_os("SNAP_USER_DATA")
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir.join("snap"));
+    let xdg_data_home = env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir.join(".local/share"));
 
     let mut path_deduper = BTreeSet::new();
     let unique_paths = [
@@ -16,7 +19,7 @@ pub fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
         home_dir.join(".var/app/com.valvesoftware.Steam/.steam/steam"),
         home_dir.join(".var/app/com.valvesoftware.Steam/.steam/root"),
         // Standard install directories
-        home_dir.join(".local/share/Steam"),
+        xdg_data_home.join("Steam"),
         home_dir.join(".steam/steam"),
         home_dir.join(".steam/root"),
         home_dir.join(".steam/debian-installation"),

--- a/src/locate/linux.rs
+++ b/src/locate/linux.rs
@@ -5,10 +5,9 @@ use crate::{error::LocateError, Error, Result};
 pub fn locate_steam_dir_helper() -> Result<Vec<PathBuf>> {
     // Steam's installation location is pretty easy to find on Linux, too, thanks to the symlink in $USER
     let home_dir = env::home_dir().ok_or_else(|| Error::locate(LocateError::no_home()))?;
-    let snap_dir = match env::var("SNAP_USER_DATA") {
-        Ok(snap_dir) => PathBuf::from(snap_dir),
-        Err(_) => home_dir.join("snap"),
-    };
+    let snap_dir = env::var_os("SNAP_USER_DATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir.join("snap"));
 
     let mut path_deduper = BTreeSet::new();
     let unique_paths = [


### PR DESCRIPTION
The Steam launcher installs Steam in `$XDG_DATA_HOME/Steam`, which may not necessarily be `$HOME/.local/share/Steam`. This MR checks for that instead.

The first commit also changes the Snap env var lookup to use the non-fallible `args_os`, which is adequate for converting into a `PathBuf`.